### PR TITLE
Integrate with Speedrun Relic Timer

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -9,6 +9,8 @@ pub struct Data<'a> {
     combat: Singleton<CombatManagerBinding>,
     encounter: EncounterBinding,
     title_screen: TitleScreen<'a>,
+    speedrun: Singleton<SpeedrunManagerBinding>,
+    speedrun_timer: SpeedrunTimerBinding,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -19,6 +21,12 @@ pub enum GameStart {
     RelicScreen,
     JustStarted,
     Unknown,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum SpeedrunRelic {
+    Inactive,
+    Active(f64),
 }
 
 impl Data<'_> {
@@ -72,6 +80,20 @@ impl Data<'_> {
     pub fn resolve_encounter(&self, address: Address64) -> Option<Encounter> {
         self.encounter.read(self.process, address.into()).ok()
     }
+
+    pub fn speedrun_time(&self) -> Option<SpeedrunRelic> {
+        let speedrun_manager = self.speedrun.read(self.process)?;
+        if !speedrun_manager.relic_active {
+            return Some(SpeedrunRelic::Inactive);
+        }
+
+        let timer = self
+            .speedrun_timer
+            .read(self.process, speedrun_manager.timer.into())
+            .ok()?;
+
+        Some(SpeedrunRelic::Active(timer.time))
+    }
 }
 
 #[derive(Class)]
@@ -84,6 +106,14 @@ struct LevelManager {
 struct CombatManager {
     #[rename = "currentEncounter"]
     encounter: Address64,
+}
+
+#[derive(Class, Debug)]
+pub struct Encounter {
+    #[rename = "encounterDone"]
+    pub done: bool,
+    #[rename = "bossEncounter"]
+    pub boss: bool,
 }
 
 #[derive(Class)]
@@ -112,12 +142,18 @@ struct DifficultySelectionScreen {
     active: bool,
 }
 
-#[derive(Class, Debug)]
-pub struct Encounter {
-    #[rename = "encounterDone"]
-    pub done: bool,
-    #[rename = "bossEncounter"]
-    pub boss: bool,
+#[derive(Class)]
+struct SpeedrunManager {
+    #[rename = "isSpeedRunning"]
+    relic_active: bool,
+    #[rename = "speedrunTimer"]
+    timer: Address64,
+}
+
+#[derive(Class)]
+struct SpeedrunTimer {
+    #[rename = "timerInSecond"]
+    time: f64,
 }
 
 impl<'a> Data<'a> {
@@ -153,9 +189,11 @@ impl<'a> Data<'a> {
         let char_select = bind!(CharacterSelectionScreen);
         let relic_select = bind!(RelicSelectionScreen);
         let difficulty_select = bind!(DifficultySelectionScreen);
+        let speedrun = bind!(singleton SpeedrunManager);
         let level = bind!(singleton LevelManager);
         let combat = bind!(singleton CombatManager);
         let encounter = bind!(Encounter);
+        let speedrun_timer = bind!(SpeedrunTimer);
 
         let title_screen = bind!(TitleSequenceManager);
         let title_screen = TitleScreen {
@@ -173,6 +211,8 @@ impl<'a> Data<'a> {
             combat,
             encounter,
             title_screen,
+            speedrun,
+            speedrun_timer,
         }
     }
 }
@@ -194,7 +234,7 @@ macro_rules! impl_binding {
     };
 }
 
-impl_binding!(LevelManager, CombatManager,);
+impl_binding!(LevelManager, CombatManager, SpeedrunManager);
 
 struct TitleScreen<'a> {
     process: &'a Process,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
-use crate::data::{Data, GameStart};
+use crate::data::{Data, GameStart, SpeedrunRelic};
 use asr::{
     future::next_tick,
     settings::Gui,
+    time::Duration,
     timer::{self, TimerState},
     watcher::Watcher,
     Address64, Process,
@@ -57,8 +58,9 @@ asr::panic_handler!();
 
 async fn main() {
     asr::set_tick_rate(60.0);
-    let mut settings = Settings::register();
+    let settings = Settings::register();
     log!("Loaded settings: {settings:?}");
+    let mut settings = LiveSettings::new(settings);
 
     loop {
         let process = Process::wait_attach("SeaOfStars.exe").await;
@@ -82,6 +84,17 @@ async fn main() {
                         }
                         TimerState::Running => {
                             game_start = GameStart::Unknown;
+
+                            match data.speedrun_time() {
+                                Some(SpeedrunRelic::Inactive) => {
+                                    settings.disable_speedrun_relic();
+                                }
+                                Some(SpeedrunRelic::Active(time)) => {
+                                    settings.enable_speedrun_relic();
+                                    act(Some(Action::SetGameTime(time)), &settings)
+                                }
+                                None => {}
+                            }
 
                             let action = progress.act(&data);
                             act(action, &settings);
@@ -116,6 +129,15 @@ pub struct Settings {
     /// Split on finished boss encounters
     #[default = true]
     split: bool,
+
+    /// Use the speedrun relic timer instead of the load remover
+    #[default = false]
+    speedrun_relic: bool,
+}
+
+struct LiveSettings {
+    settings: Settings,
+    speedrun_relic: bool,
 }
 
 #[derive(Debug)]
@@ -125,6 +147,7 @@ enum Action {
     Split,
     Pause,
     Resume,
+    SetGameTime(f64),
 }
 
 struct Progress {
@@ -183,18 +206,39 @@ impl Progress {
     }
 }
 
-impl Settings {
+impl LiveSettings {
+    fn new(settings: Settings) -> Self {
+        let speedrun_relic = settings.speedrun_relic;
+        Self {
+            settings,
+            speedrun_relic,
+        }
+    }
+
+    fn update(&mut self) {
+        self.settings.update();
+    }
+
+    fn disable_speedrun_relic(&mut self) {
+        self.speedrun_relic = false;
+    }
+
+    fn enable_speedrun_relic(&mut self) {
+        self.speedrun_relic = self.settings.speedrun_relic;
+    }
+
     fn filter(&self, action: &Action) -> bool {
         match action {
-            Action::Pause | Action::Resume => self.remove_loads,
-            Action::StartCharacter => self.start,
-            Action::StartRelic => self.relic_start,
-            Action::Split => self.split,
+            Action::Pause | Action::Resume => self.settings.remove_loads && !self.speedrun_relic,
+            Action::StartCharacter => self.settings.start,
+            Action::StartRelic => self.settings.relic_start,
+            Action::Split => self.settings.split,
+            Action::SetGameTime(_) => self.speedrun_relic,
         }
     }
 }
 
-fn act(action: Option<Action>, settings: &Settings) {
+fn act(action: Option<Action>, settings: &LiveSettings) {
     if let Some(action) = action.filter(|o| settings.filter(o)) {
         log!("Decided on an action: {action:?}");
         match (action, timer::state() == TimerState::Running) {
@@ -214,7 +258,13 @@ fn act(action: Option<Action>, settings: &Settings) {
                 log!("Resume game time");
                 timer::resume_game_time();
             }
-            _ => {}
+            (Action::SetGameTime(time), true) => {
+                let time = Duration::seconds_f64(time);
+                timer::set_game_time(time);
+            }
+
+            (Action::StartCharacter | Action::StartRelic, true) => {}
+            (Action::Split | Action::Pause | Action::Resume | Action::SetGameTime(_), false) => {}
         }
     }
 }


### PR DESCRIPTION
# Changes

* You can enable integration in the layout settings of LiveSplit
* When the setting is enabled **and** the speedrun relic is active, the relice timer will be reported to LiveSplit as "Game Time", replacing the previous load remover (requires the same alternative timing source configuration that the load remover required)
* When the setting is enabled, but the relic is not active, the previous load remover is used
* When the setting is disabled, the previous load remover will always be used, no matter if the relic is used or not
